### PR TITLE
Follower 팔로우 상태 버그 조치

### DIFF
--- a/src/components/profile/FollowerCard.jsx
+++ b/src/components/profile/FollowerCard.jsx
@@ -13,13 +13,16 @@ function FollowerCard({ profileImage, userName, accountName }) {
   async function getOwnFollowing() {
     const token = localStorage.getItem('token');
     const url = SERVER_BASE_URL;
-    const response = await axios(`${url}/profile/${account}/following`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
+    const response = await axios(
+      `${url}/profile/${account}/following?limit=10000`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
       },
-    });
+    );
     setOwnFollowingList(response.data);
     response.data.forEach((follow) => {
       if (follow.accountname === accountName) {


### PR DESCRIPTION
- follower들을 팔로우 했는지 상태를 확인하는 로직에서 이전에 최대 10명만 불러오는 오류로 인한 버그 발생

> limit=10000을 통해 조치 완료